### PR TITLE
Fixed bug with the jsx compiler option not being handled properly.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const anymatch = require('anymatch');
 const path = require('path');
 
 const resolveEnum = (choice, opts) => {
-  const defaultValue = 1; // CommonJS/ES5 defaults;
+  const defaultValue = 1; // CommonJS/ES5/Preserve JSX defaults
   if (!choice) {
     return defaultValue;
   }
@@ -46,6 +46,7 @@ class TypeScriptCompiler {
     });
     this.options.module = resolveEnum(this.options.module, ts.ModuleKind);
     this.options.target = resolveEnum(this.options.target, ts.ScriptTarget);
+    this.options.jsx = resolveEnum(this.options.jsx, ts.JsxEmit);
     this.options.emitDecoratorMetadata = this.options.emitDecoratorMetadata !== false,
     this.options.experimentalDecorators = this.options.experimentalDecorators !== false,
     this.options.sourceMap = !!config.sourceMaps;


### PR DESCRIPTION
The jsx compiler option was previously being passed through to tsc as a string - but tsc expects it to be an enum value of type `JsxEmit`. This change resolves the `jsx` string value to the equivalent `JsxEmit` enum value in the same way that the `module` and `target` compiler options are handled.
